### PR TITLE
Persist door state

### DIFF
--- a/Lib/SceneScrollerClass.js
+++ b/Lib/SceneScrollerClass.js
@@ -1,7 +1,7 @@
 import { ModuleName, ssc } from "../ss-initialize.js";
 import * as Viewport from "./ViewportClass.js";
 import { ScrollerTokenDocument } from "./TokenClass.js";
-import { log } from "./functions.js";
+import { getUUID, log } from "./functions.js";
 
 /**
  * A class that will be publicly available containing a schema for
@@ -327,6 +327,14 @@ export class SceneScroller_Cache {
         log(false, `Wall with id ${wallDoc.id} has been deleted from cache.`);
     }
 
+    async updateDoorState(wallDoc, state) {
+        if ( !this.walls.has(wallDoc.id) ) return;
+        this.walls.set(wallDoc.id, wallDoc);
+        // Update the compendium source too.
+        const sourceScene = ssc.compendiumSourceFromCache(wallDoc.parentUUID[0]);
+        await sourceScene.updateEmbeddedDocuments(wallDoc.constructor.documentName, [{_id: wallDoc.id, ds: state}])
+    }
+    
     /**
      * Adds a Light Document to the cache
      * @param {object} lightDoc A Foundry Light Document

--- a/Lib/SceneScrollerClass.js
+++ b/Lib/SceneScrollerClass.js
@@ -327,12 +327,11 @@ export class SceneScroller_Cache {
         log(false, `Wall with id ${wallDoc.id} has been deleted from cache.`);
     }
 
-    async updateDoorState(wallDoc, state) {
-        if ( !this.walls.has(wallDoc.id) ) return;
-        this.walls.set(wallDoc.id, wallDoc);
+    async updateDoorState(wallDoc, {doorState = undefined} ={}) {
+        wallDoc.updateSource({ds: doorState})
         // Update the compendium source too.
         const sourceScene = ssc.compendiumSourceFromCache(wallDoc.parentUUID[0]);
-        await sourceScene.updateEmbeddedDocuments(wallDoc.constructor.documentName, [{_id: wallDoc.id, ds: state}])
+        await sourceScene.updateEmbeddedDocuments(wallDoc.constructor.documentName, [{_id: wallDoc.id, ds: doorState}])
     }
     
     /**

--- a/Lib/ViewportClass.js
+++ b/Lib/ViewportClass.js
@@ -571,6 +571,9 @@ function _doorControlLeftClick(event) {
     /** This portion changed to not attempt to save to db. */
     this.document.ds = state === states.CLOSED ? states.OPEN : states.CLOSED;
     drawDoorControl(this);
+    /** Save the door state in cache and in compendium source */
+    ssc.updateDoorState(this.document, this.document.ds);
+
 
     // Doesn't make sense that this has to be done.... ???
     for (const token of canvas.tokens.placeables) {

--- a/Lib/ViewportClass.js
+++ b/Lib/ViewportClass.js
@@ -572,7 +572,7 @@ function _doorControlLeftClick(event) {
     this.document.ds = state === states.CLOSED ? states.OPEN : states.CLOSED;
     drawDoorControl(this);
     /** Save the door state in cache and in compendium source */
-    ssc.updateDoorState(this.document, this.document.ds);
+    ssc.updateDoorState(this.document, {doorState: this.document.ds});
 
 
     // Doesn't make sense that this has to be done.... ???
@@ -604,6 +604,9 @@ function _doorControlRightClick(event) {
     /** This portion changed to not attempt to save to db. */
     this.document.ds = state === states.LOCKED ? states.CLOSED : states.LOCKED;
     drawDoorControl(this);
+
+    /** Save the door state in cache and in compendium source */
+    ssc.updateDoorState(this.document, {doorState: this.document.ds});
 }
 
 /**


### PR DESCRIPTION
Door state is persisted by saving the door state in the Scene Scroller Cache (ssc) and in the source scene stored in the compendium.

Resolves issue #5 